### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-kotlinTarget = "2.2"
+kotlinTarget = "2.3"
 javaTarget = "17"
 
-kotlin = "2.2.21"
+kotlin = "2.3.10"
 asm = "9.9.1"
 
-xemanticKotlinTest = "1.17.2"
+xemanticKotlinTest = "1.17.3"
 
 versionsPlugin = "0.53.0"
 dokkaPlugin = "2.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates dependencies to their latest available versions:

- Kotlin: 2.2.21 -> 2.3.10 (also updates kotlinTarget 2.2 -> 2.3)
- xemantic-kotlin-test: 1.17.2 -> 1.17.3
- Gradle wrapper: 9.3.0 -> 9.3.1

Note: jreleaser 1.23.0 was released today but its artifacts are not yet fully available on Gradle Plugin Portal, keeping at 1.22.0 for now.

Closes #4

Generated with [Claude Code](https://claude.ai/code)