### PR TITLE
fix: remove redundant public visibility modifiers

### DIFF
--- a/src/commonMain/kotlin/com/xemantic/typescript/compiler/Main.kt
+++ b/src/commonMain/kotlin/com/xemantic/typescript/compiler/Main.kt
@@ -31,7 +31,7 @@ package com.xemantic.typescript.compiler
  * - `0` — compilation succeeded (possibly with warnings)
  * - `1` — compilation failed with errors, or invalid arguments
  */
-public fun main(args: Array<String>) {
+fun main(args: Array<String>) {
     if (args.isEmpty()) {
         error("Usage: xemantic-typescript-compiler <input.ts> [output.js]\nError: no input file specified")
     }

--- a/src/commonMain/kotlin/com/xemantic/typescript/compiler/TypeScriptCompiler.kt
+++ b/src/commonMain/kotlin/com/xemantic/typescript/compiler/TypeScriptCompiler.kt
@@ -24,12 +24,12 @@ package com.xemantic.typescript.compiler
  * @property diagnostics The list of diagnostic messages (errors, warnings, hints)
  *   produced during compilation.
  */
-public data class CompilationResult(
+data class CompilationResult(
     val javascript: String?,
     val diagnostics: List<Diagnostic> = emptyList(),
 ) {
     /** `true` if any diagnostic with [DiagnosticCategory.Error] category was produced. */
-    public val hasErrors: Boolean get() = diagnostics.any { it.category == DiagnosticCategory.Error }
+    val hasErrors: Boolean get() = diagnostics.any { it.category == DiagnosticCategory.Error }
 }
 
 /**
@@ -43,7 +43,7 @@ public data class CompilationResult(
  * @property line The 1-based line number within [fileName], or `null` if not applicable.
  * @property character The 1-based column number within the line, or `null` if not applicable.
  */
-public data class Diagnostic(
+data class Diagnostic(
     val message: String,
     val category: DiagnosticCategory,
     val code: Int,
@@ -56,7 +56,7 @@ public data class Diagnostic(
  * The severity category of a [Diagnostic] message, mirroring the TypeScript SDK's
  * `DiagnosticCategory` enum.
  */
-public enum class DiagnosticCategory {
+enum class DiagnosticCategory {
     Warning,
     Error,
     Message,
@@ -76,7 +76,7 @@ public enum class DiagnosticCategory {
  * println(result.javascript)
  * ```
  */
-public class TypeScriptCompiler {
+class TypeScriptCompiler {
 
     /**
      * Compiles the given TypeScript [source] string to JavaScript.
@@ -90,7 +90,7 @@ public class TypeScriptCompiler {
      * @return A [CompilationResult] containing the JavaScript output and any diagnostics.
      * @throws NotImplementedError until the compiler is implemented.
      */
-    public fun compile(
+    fun compile(
         source: String,
         fileName: String = "input.ts",
     ): CompilationResult {


### PR DESCRIPTION
Removed redundant `public` visibility modifiers from all declarations in `TypeScriptCompiler.kt` and `Main.kt`. In Kotlin, `public` is the default visibility, so explicitly declaring it produces compiler warnings.

Closes #10

Generated with [Claude Code](https://claude.ai/code)